### PR TITLE
Fix #16 and #21

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -14,6 +14,7 @@ env:
   TEST_URL: ${{secrets.TEST_URL}}
   TEST_SLACK_URL: ${{secrets.TEST_SLACK_URL}}
   TEST_WEBEX_URL: ${{secrets.TEST_WEBEX_URL}}
+  TEST_DISCORD_URL: ${{secrets.TEST_DISCORD_URL}}
 
 jobs:
   test:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -22,22 +22,22 @@ jobs:
       matrix:
         include:
           # Python 3.9 is the primary dev version
-          - os: windows-2022
-            python-version: '3.9'
-          - os: windows-latest
-            python-version: '3.9'
-          - os: ubuntu-latest
-            python-version: '3.9'
+          # - os: windows-2022
+          #   python-version: '3.9'
+          # - os: windows-latest
+          #   python-version: '3.9'
+          # - os: ubuntu-latest
+          #   python-version: '3.9'
           # Python 3.6 is the minimum supported version
           - os: windows-2022
             python-version: '3.6'
-          - os: ubuntu-20.04
-            python-version: '3.6'
-          # Python 3.14 is the latest (Oct 14th) version
-          - os: windows-latest
-            python-version: '3.14'
-          - os: ubuntu-latest
-            python-version: '3.14'
+          # - os: ubuntu-20.04
+          #   python-version: '3.6'
+          # # Python 3.14 is the latest (Oct 14th) version
+          # - os: windows-latest
+          #   python-version: '3.14'
+          # - os: ubuntu-latest
+          #   python-version: '3.14'
     environment: test
     steps:
       - name: Checkout code

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -22,22 +22,22 @@ jobs:
       matrix:
         include:
           # Python 3.9 is the primary dev version
-          - os: windows-2022
-            python-version: '3.9'
-          - os: windows-latest
-            python-version: '3.9'
+          # - os: windows-2022
+          #   python-version: '3.9'
+          # - os: windows-latest
+          #   python-version: '3.9'
+          # - os: ubuntu-latest
+          #   python-version: '3.9'
+          # # Python 3.6 is the minimum supported version
+          # - os: windows-2022
+          #   python-version: '3.6'
           - os: ubuntu-latest
-            python-version: '3.9'
-          # Python 3.6 is the minimum supported version
-          - os: windows-2022
             python-version: '3.6'
-          - os: ubuntu-20.04
-            python-version: '3.6'
-          # Python 3.14 is the latest (Oct 14th) version
-          - os: windows-latest
-            python-version: '3.14'
-          - os: ubuntu-latest
-            python-version: '3.14'
+          # # Python 3.14 is the latest (Oct 14th) version
+          # - os: windows-latest
+          #   python-version: '3.14'
+          # - os: ubuntu-latest
+          #   python-version: '3.14'
     environment: test
     steps:
       - name: Checkout code

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -5,10 +5,6 @@ on:
     branches:
       - main
       - dev
-  pull_request:
-    branches:
-      - main
-      - dev
 
 env:
   TEST_URL: ${{secrets.TEST_URL}}

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -21,19 +21,19 @@ jobs:
     strategy:
       matrix:
         include:
-          # Python 3.9 on your specified Windows and Ubuntu versions
+          # Python 3.9 is the primary dev version
           - os: windows-2022
             python-version: '3.9'
           - os: windows-latest
             python-version: '3.9'
           - os: ubuntu-latest
             python-version: '3.9'
-          # Python 3.6 on compatible runners (older versions support 3.6)
-          - os: windows-2019
+          # Python 3.6 is the minimum supported version
+          - os: windows-2022
             python-version: '3.6'
           - os: ubuntu-20.04
             python-version: '3.6'
-          # Python 3.12 (latest stable) on compatible runners
+          # Python 3.14 is the latest (Oct 14th) version
           - os: windows-latest
             python-version: '3.14'
           - os: ubuntu-latest

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -31,7 +31,7 @@ jobs:
           # # Python 3.6 is the minimum supported version
           # - os: windows-2022
           #   python-version: '3.6'
-          - os: ubuntu-latest
+          - os: ubuntu-20.04
             python-version: '3.6'
           # # Python 3.14 is the latest (Oct 14th) version
           # - os: windows-latest

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -22,22 +22,21 @@ jobs:
       matrix:
         include:
           # Python 3.9 is the primary dev version
-          # - os: windows-2022
-          #   python-version: '3.9'
-          # - os: windows-latest
-          #   python-version: '3.9'
-          # - os: ubuntu-latest
-          #   python-version: '3.9'
-          # # Python 3.6 is the minimum supported version
-          # - os: windows-2022
-          #   python-version: '3.6'
-          - os: ubuntu-20.04
+          - os: windows-2022
+            python-version: '3.9'
+          - os: windows-latest
+            python-version: '3.9'
+          - os: ubuntu-latest
+            python-version: '3.9'
+          # Python 3.6 is the minimum supported version
+          - os: windows-2022
             python-version: '3.6'
-          # # Python 3.14 is the latest (Oct 14th) version
-          # - os: windows-latest
-          #   python-version: '3.14'
-          # - os: ubuntu-latest
-          #   python-version: '3.14'
+          # github actions does not support any other runners with python 3.6
+          # Python 3.14 is the latest (Oct 14th 2025) version
+          - os: windows-latest
+            python-version: '3.14'
+          - os: ubuntu-latest
+            python-version: '3.14'
     environment: test
     steps:
       - name: Checkout code

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -20,8 +20,24 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-2022, windows-latest, ubuntu-latest]
-        python-version: ['3.6', '3.9', '3.14']
+        include:
+          # Python 3.9 on your specified Windows and Ubuntu versions
+          - os: windows-2022
+            python-version: '3.9'
+          - os: windows-latest
+            python-version: '3.9'
+          - os: ubuntu-latest
+            python-version: '3.9'
+          # Python 3.6 on compatible runners (older versions support 3.6)
+          - os: windows-2019
+            python-version: '3.6'
+          - os: ubuntu-20.04
+            python-version: '3.6'
+          # Python 3.12 (latest stable) on compatible runners
+          - os: windows-latest
+            python-version: '3.14'
+          - os: ubuntu-latest
+            python-version: '3.14'
     environment: test
     steps:
       - name: Checkout code

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -22,22 +22,22 @@ jobs:
       matrix:
         include:
           # Python 3.9 is the primary dev version
-          # - os: windows-2022
-          #   python-version: '3.9'
-          # - os: windows-latest
-          #   python-version: '3.9'
-          # - os: ubuntu-latest
-          #   python-version: '3.9'
+          - os: windows-2022
+            python-version: '3.9'
+          - os: windows-latest
+            python-version: '3.9'
+          - os: ubuntu-latest
+            python-version: '3.9'
           # Python 3.6 is the minimum supported version
           - os: windows-2022
             python-version: '3.6'
-          # - os: ubuntu-20.04
-          #   python-version: '3.6'
-          # # Python 3.14 is the latest (Oct 14th) version
-          # - os: windows-latest
-          #   python-version: '3.14'
-          # - os: ubuntu-latest
-          #   python-version: '3.14'
+          - os: ubuntu-20.04
+            python-version: '3.6'
+          # Python 3.14 is the latest (Oct 14th) version
+          - os: windows-latest
+            python-version: '3.14'
+          - os: ubuntu-latest
+            python-version: '3.14'
     environment: test
     steps:
       - name: Checkout code

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -38,8 +38,3 @@ jobs:
       - name: Run tests
         run: tox
 
-tox.ini:
-
-[tox]
-envlist = py36,py39,py314  # Minimum, stable, latest
-

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -20,20 +20,26 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-2019, windows-2022, windows-latest, ubuntu-latest]
+        os: [windows-2022, windows-latest, ubuntu-latest]
+        python-version: ['3.6', '3.9', '3.14']
     environment: test
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Python
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: ${{ matrix.python-version }}
 
       - name: Install Tox
         run: pip install tox
 
       - name: Run tests
         run: tox
-        
+
+tox.ini:
+
+[tox]
+envlist = py36,py39,py314  # Minimum, stable, latest
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ python = ">=3.6"
 requests = ">=2.25.1"
 setuptools = ">=40.6.3"
 toml = ">=0.6.0"
+importlib-metadata = {version = ">=1.0", python = "<3.8"}
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "whecho"
-version = "0.0.5"
+version = "0.0.6"
 description = "Linux echo with webhooks! ⚓"
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,6 @@ classifiers = [
 [tool.poetry.dependencies]
 python = ">=3.6"
 requests = ">=2.25.1"
-setuptools = ">=40.6.3"
 toml = ">=0.6.0"
 importlib-metadata = {version = ">=1.0", python = "<3.8"}
 

--- a/tests/test_auto_machine.py
+++ b/tests/test_auto_machine.py
@@ -4,7 +4,6 @@ import os
 import subprocess
 import re
 import socket
-import platform
 from whecho import _config as config
 import toml
 from test_whecho_simple import simple_post

--- a/tests/test_post_message.py
+++ b/tests/test_post_message.py
@@ -1,7 +1,5 @@
 import os
-import subprocess
-import re
-import platform
+
 from whecho._send_message import post_simple
 
 def test_empty_url():

--- a/tests/test_post_message.py
+++ b/tests/test_post_message.py
@@ -2,15 +2,6 @@ import os
 
 from whecho._send_message import post_simple
 
-def test_empty_url():
-    # test that an error is raised when no URL is passed
-    try:
-        post_simple("This should fail", None, conf={"default_url": None})
-    except ValueError as e:
-        assert str(e) == 'No URL passed. Did you run whecho --init?'
-    else:
-        assert False, "Expected Error message was not delivered"
-
 def test_no_url_in_config():
     # test that an error is raised when no URL is passed and no URL in config
     try:
@@ -33,6 +24,5 @@ def test_no_message():
         assert False, "Expected Error message was not delivered"
 
 if __name__ == "__main__":
-    test_empty_url()
     test_no_url_in_config()
     test_no_message()

--- a/tests/test_post_message.py
+++ b/tests/test_post_message.py
@@ -1,0 +1,40 @@
+import os
+import subprocess
+import re
+import platform
+from whecho._send_message import post_simple
+
+def test_empty_url():
+    # test that an error is raised when no URL is passed
+    try:
+        post_simple("This should fail", None, conf={"default_url": None})
+    except ValueError as e:
+        assert str(e) == 'No URL passed. Did you run whecho --init?'
+    else:
+        assert False, "Expected Error message was not delivered"
+
+def test_no_url_in_config():
+    # test that an error is raised when no URL is passed and no URL in config
+    try:
+        post_simple("This should fail", None, conf={'default_url': None})
+    except ValueError as e:
+        assert str(e) == 'No URL passed. Did you run whecho --init?'
+    else:
+        assert False, "Expected Error message was not delivered"
+
+def test_no_message():
+    # test that an error is raised when no message is passed
+    url = os.environ.get("TEST_URL", None)
+    if not url:
+        raise ValueError(f'No test URL passed. Did you set the TEST_URL environment variable?')
+    try:
+        post_simple("", url)
+    except ValueError as e:
+        assert str(e) == 'No message passed. Try whecho --help for more info.'
+    else:
+        assert False, "Expected Error message was not delivered"
+
+if __name__ == "__main__":
+    test_empty_url()
+    test_no_url_in_config()
+    test_no_message()

--- a/tests/test_whecho_simple.py
+++ b/tests/test_whecho_simple.py
@@ -58,38 +58,9 @@ def test_empty_url():
     else:
         assert False, "Expected Error message was not delivered"
 
-def test_no_url_in_config():
-    # test that an error is raised when no URL is passed and no default URL in config
-    # create a temporary config with no default URL
-    temp_config = {'default_url': None,
-                  'version': '0.0.0',
-                  'user': 'test_user',
-                  'os': platform.system(),
-                  'machine': "auto",}
-    try:
-        whecho_simple("This should fail", None, temp_config)
-    except ValueError as e:
-        assert str(e) == 'No URL passed. Did you run whecho --init?'
-    else:
-        assert False, "Expected Error message was not delivered"
-
-def test_no_message():
-    # test that an error is raised when no message is passed
-    url = os.environ.get('TEST_URL', None)
-    if not url:
-        raise ValueError('No test URL passed. Did you set the $TEST_URL environment variable?')
-    try:
-        whecho_simple("", url)
-    except ValueError as e:
-        assert str(e) == 'No message passed. Try whecho --help for more info.'
-    else:
-        assert False, "Expected Error message was not delivered"
-
 if __name__ == "__main__":
     simple_post() # only test discord with main function (duplicated in test_auto_machine.py)
     test_simple_slack()
     test_simple_webex()
     test_simple_discord()
     test_empty_url()
-    test_no_url_in_config()
-    test_no_message()

--- a/tests/test_whecho_simple.py
+++ b/tests/test_whecho_simple.py
@@ -47,13 +47,7 @@ def test_simple_webex():
 
 def test_simple_discord():
     # test discord url with python function
-    # simple_post('TEST_DISCORD_URL', False)
-    # --- debugging code for github actions ---
-    # list out the names of all the environment variables
-    print("Environment variables: ", end="")
-    for key in os.environ.keys():
-        print(key, end=", ")
-    print()
+    simple_post('TEST_DISCORD_URL', False)
     
 
 if __name__ == "__main__":

--- a/tests/test_whecho_simple.py
+++ b/tests/test_whecho_simple.py
@@ -54,4 +54,9 @@ if __name__ == "__main__":
     simple_post() # only test discord with main function (duplicated in test_auto_machine.py)
     test_simple_slack()
     test_simple_webex()
-    test_simple_discord()
+    # test_simple_discord()
+    # list out the names of all the environment variables
+    print("Environment variables: ", end="")
+    for key in os.environ.keys():
+        print(key, end=", ")
+    print()

--- a/tests/test_whecho_simple.py
+++ b/tests/test_whecho_simple.py
@@ -47,16 +47,18 @@ def test_simple_webex():
 
 def test_simple_discord():
     # test discord url with python function
-    simple_post('TEST_DISCORD_URL', False)
+    # simple_post('TEST_DISCORD_URL', False)
+    # --- debugging code for github actions ---
+    # list out the names of all the environment variables
+    print("Environment variables: ", end="")
+    for key in os.environ.keys():
+        print(key, end=", ")
+    print()
     
 
 if __name__ == "__main__":
     simple_post() # only test discord with main function (duplicated in test_auto_machine.py)
     test_simple_slack()
     test_simple_webex()
-    # test_simple_discord()
-    # list out the names of all the environment variables
-    print("Environment variables: ", end="")
-    for key in os.environ.keys():
-        print(key, end=", ")
-    print()
+    test_simple_discord()
+    

--- a/tests/test_whecho_simple.py
+++ b/tests/test_whecho_simple.py
@@ -44,9 +44,14 @@ def test_simple_slack():
 def test_simple_webex():
     # test webex url with python function
     simple_post('TEST_WEBEX_URL', False)
+
+def test_simple_discord():
+    # test discord url with python function
+    simple_post('TEST_DISCORD_URL', False)
     
 
 if __name__ == "__main__":
     simple_post() # only test discord with main function (duplicated in test_auto_machine.py)
     test_simple_slack()
     test_simple_webex()
+    test_simple_discord()

--- a/tests/test_whecho_simple.py
+++ b/tests/test_whecho_simple.py
@@ -49,10 +49,47 @@ def test_simple_discord():
     # test discord url with python function
     simple_post('TEST_DISCORD_URL', False)
     
+def test_empty_url():
+    # test that an error is raised when no URL is passed
+    try:
+        whecho_simple("This should fail", None)
+    except ValueError as e:
+        assert str(e) == 'No URL passed. Did you run whecho --init?'
+    else:
+        assert False, "Expected Error message was not delivered"
+
+def test_no_url_in_config():
+    # test that an error is raised when no URL is passed and no default URL in config
+    # create a temporary config with no default URL
+    temp_config = {'default_url': None,
+                  'version': '0.0.0',
+                  'user': 'test_user',
+                  'os': platform.system(),
+                  'machine': "auto",}
+    try:
+        whecho_simple("This should fail", None, temp_config)
+    except ValueError as e:
+        assert str(e) == 'No URL passed. Did you run whecho --init?'
+    else:
+        assert False, "Expected Error message was not delivered"
+
+def test_no_message():
+    # test that an error is raised when no message is passed
+    url = os.environ.get('TEST_URL', None)
+    if not url:
+        raise ValueError('No test URL passed. Did you set the $TEST_URL environment variable?')
+    try:
+        whecho_simple("", url)
+    except ValueError as e:
+        assert str(e) == 'No message passed. Try whecho --help for more info.'
+    else:
+        assert False, "Expected Error message was not delivered"
 
 if __name__ == "__main__":
     simple_post() # only test discord with main function (duplicated in test_auto_machine.py)
     test_simple_slack()
     test_simple_webex()
     test_simple_discord()
-    
+    test_empty_url()
+    test_no_url_in_config()
+    test_no_message()

--- a/tox.ini
+++ b/tox.ini
@@ -16,4 +16,4 @@ deps =
     toml
     requests
 commands =
-    pytest -s
+    pytest

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ passenv =
     TEST_URL
     TEST_SLACK_URL
     TEST_WEBEX_URL
+    TEST_DISCORD_URL
 deps =
     pytest
     toml

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ envlist = py36,py39,py314
 isolated_build = true
 
 [testenv]
+skip_missing_interpreters = true
 setenv =
     PYTHONIOENCODING = utf-8
 passenv = 

--- a/tox.ini
+++ b/tox.ini
@@ -15,4 +15,4 @@ deps =
     toml
     requests
 commands =
-    pytest
+    pytest -s

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py39
+envlist = py36,py39,py314
 
 [testenv]
 passenv = 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py39,py314
+envlist = py
 isolated_build = true
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,8 @@ envlist = py36,py39,py314
 isolated_build = true
 
 [testenv]
+setenv =
+    PYTHONIOENCODING = utf-8
 passenv = 
     TEST_URL
     TEST_SLACK_URL

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
 envlist = py36,py39,py314
+isolated_build = true
 
 [testenv]
 passenv = 

--- a/whecho/README.md
+++ b/whecho/README.md
@@ -4,6 +4,8 @@ Thank you for your interest in whecho's source code. New features and contributi
 
 Raise an issue or submit a pull request if you have any new ideas!
 
+**Do not open PR's to `main`**, github actions stores the webhook urls in repository secrets. If it is your first time contributing please create a new branch and **create the PR to `dev`**. The core maintainers will then evaluate the contribution and run it in github actions to verify no regression in functionality.
+
 ## building the project
 - clone the repo & go to the directory of the `pyproject.toml` file
 - clone the environment using the supplied environment.yml file
@@ -20,4 +22,5 @@ Raise an issue or submit a pull request if you have any new ideas!
   - `TEST_URL` pointing to a discord webhook
   - `TEST_SLACK_URL` pointing to a slack webhook
   - `TEST_WEBEX_URL` pointing to a webex webhook
+  - `TEST_DISCORD_URL` pointing to a discord webhook (ideally using the discordapp.com endpoint instead)
   - tox makes use of these environment variables during the automated testing

--- a/whecho/README.md
+++ b/whecho/README.md
@@ -4,7 +4,7 @@ Thank you for your interest in whecho's source code. New features and contributi
 
 Raise an issue or submit a pull request if you have any new ideas!
 
-**Do not open PR's to `main`**, github actions stores the webhook urls in repository secrets. If it is your first time contributing please create a new branch and **create the PR to `dev`**. The core maintainers will then evaluate the contribution and run it in github actions to verify no regression in functionality.
+**Do not open PRs to `main`**, GitHub Actions stores the webhook URLs in repository secrets. If it is your first time contributing please create a new branch and **create the PR to `dev`**. The core maintainers will then evaluate the contribution and run it in GitHub Actions to verify no regression in functionality.
 
 ## building the project
 - clone the repo & go to the directory of the `pyproject.toml` file

--- a/whecho/_config.py
+++ b/whecho/_config.py
@@ -2,7 +2,10 @@
 
 import os
 import getpass
-import importlib.metadata
+try: # python >= 3.8
+    import importlib.metadata as metadata
+except ImportError: # python < 3.8
+    import importlib_metadata as metadata
 import toml
 import socket
 import platform

--- a/whecho/_config.py
+++ b/whecho/_config.py
@@ -2,7 +2,7 @@
 
 import os
 import getpass
-import pkg_resources
+import importlib.metadata
 import toml
 import socket
 import platform
@@ -13,7 +13,7 @@ try:
 except Exception:
   config_username = "user"
 DEFAULT_CONFIG = {'default_url': None,
-                  'version': pkg_resources.get_distribution('whecho').version,
+                  'version': importlib.metadata.version('whecho'),
                   'user': config_username,
                   'os': platform.system(),
                   'machine': "auto",}

--- a/whecho/_config.py
+++ b/whecho/_config.py
@@ -16,7 +16,7 @@ try:
 except Exception:
   config_username = "user"
 DEFAULT_CONFIG = {'default_url': None,
-                  'version': importlib.metadata.version('whecho'),
+                  'version': metadata.version('whecho'),
                   'user': config_username,
                   'os': platform.system(),
                   'machine': "auto",}

--- a/whecho/_send_message.py
+++ b/whecho/_send_message.py
@@ -27,6 +27,7 @@ def post_simple(message, url, conf=None, debug=False):
 def get_data(conf,message,url,debug=False):
     """General get data function for all supported webhooks."""
     url_keyword_map = {"discord.com": get_discord_data,
+                       "discordapp.com": get_discord_data,
                        "slack.com": get_slack_data,
                        "webhook.office.com": get_teams_data,
                        "webexapis.com": get_webex_data}

--- a/whecho/_send_message.py
+++ b/whecho/_send_message.py
@@ -9,11 +9,13 @@ def post_simple(message, url, conf=None, debug=False):
         conf = config.get_config()
         if not url:
             url = conf['default_url']
+    if not url:
+        raise ValueError('No URL passed. Did you run whecho --init?')
+    if not message:
+        raise ValueError('No message passed. Try whecho --help for more info.')
     data = get_data(conf,message,url,debug)
     if debug:
         print(f"Data: {data}")
-    if not url:
-        raise ValueError('No URL passed. Did you run whecho --init?')
     try:
         r = requests.post(url, json=data)
         if debug:

--- a/whecho/_utilities.py
+++ b/whecho/_utilities.py
@@ -1,6 +1,9 @@
 # Contains utility functions for the whecho project.
 
-import importlib.metadata
+try: # python >= 3.8
+    import importlib.metadata as metadata
+except ImportError: # python < 3.8
+    import importlib_metadata as metadata
 import os
 from whecho import _config as config
 import toml

--- a/whecho/_utilities.py
+++ b/whecho/_utilities.py
@@ -11,7 +11,7 @@ from whecho import _send_message as send_message
 
 def get_version():
     """Prints the version of whecho and exits."""
-    print(importlib.metadata.version('whecho'))
+    print(metadata.version('whecho'))
     exit(0)
 
 def init():

--- a/whecho/_utilities.py
+++ b/whecho/_utilities.py
@@ -4,9 +4,7 @@ try: # python >= 3.8
     import importlib.metadata as metadata
 except ImportError: # python < 3.8
     import importlib_metadata as metadata
-import os
 from whecho import _config as config
-import toml
 from whecho import _send_message as send_message
 
 def get_version():

--- a/whecho/_utilities.py
+++ b/whecho/_utilities.py
@@ -1,6 +1,6 @@
 # Contains utility functions for the whecho project.
 
-import pkg_resources
+import importlib.metadata
 import os
 from whecho import _config as config
 import toml
@@ -8,7 +8,7 @@ from whecho import _send_message as send_message
 
 def get_version():
     """Prints the version of whecho and exits."""
-    print(pkg_resources.get_distribution('whecho').version)
+    print(importlib.metadata.version('whecho'))
     exit(0)
 
 def init():

--- a/whecho/whecho.py
+++ b/whecho/whecho.py
@@ -10,7 +10,8 @@ def main():
     # deal with arguments
     desc = 'Linux echo with webhooks! ⚓'
     # if terminal does not support utf-8, remove the anchor emoji from the description
-    if sys.stdout.encoding.lower() != 'utf-8':
+    encoding = getattr(sys.stdout, 'encoding', 'utf-8') or 'utf-8'
+    if encoding.lower() != 'utf-8':
         desc = 'Linux echo with webhooks!'
     parser = argparse.ArgumentParser(prog='whecho', description=desc)
     parser.add_argument('--version', action='store_true', help='Prints the version of whecho and exits.')

--- a/whecho/whecho.py
+++ b/whecho/whecho.py
@@ -4,7 +4,7 @@ from whecho._send_message import post_simple
 import requests
 from typing import Optional
 import sys
-import os
+
 
 def main():
     # deal with arguments

--- a/whecho/whecho.py
+++ b/whecho/whecho.py
@@ -3,10 +3,16 @@ from whecho import _utilities as utilities
 from whecho._send_message import post_simple
 import requests
 from typing import Optional
+import sys
+import os
 
 def main():
     # deal with arguments
-    parser = argparse.ArgumentParser(prog='whecho', description='Linux echo with webhooks! ⚓')
+    desc = 'Linux echo with webhooks! ⚓'
+    # if terminal does not support utf-8, remove the anchor emoji from the description
+    if sys.stdout.encoding.lower() != 'utf-8':
+        desc = 'Linux echo with webhooks!'
+    parser = argparse.ArgumentParser(prog='whecho', description=desc)
     parser.add_argument('--version', action='store_true', help='Prints the version of whecho and exits.')
     parser.add_argument('-m', '--msg', help='The message to echo (same as 1st positional argument).')
     parser.add_argument('message', metavar="MSG" ,nargs='*', help='The message to echo.')


### PR DESCRIPTION
This PR updates whecho to version 0.0.6. It modernizes treatment of version handling and discord webhooks.

Recently discord has updated their webhook generator to also append `app` at the end of the url. This PR not only checks for the presence of discord.com but also discordapp.com in the webhook url to determine how to handle the request. This will take care of #21.

pkg_resources is now depreciated. This PR uses `importlib.metadata` instead to get the version number for whecho. This should silence the warning present with #16.

For development work, github has depreciated most of the python 3.6 runners, such as the windows-2019 runner. This PR switches the windows runner to the windows-2022 runner to maintain python 3.6 test coverage. It also adds a new test case to `test_whecho_simple.py` to cover the edge case for #21.